### PR TITLE
HashHub Research API の形式に合わせて変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,14 +9,16 @@ tmpl = env.get_template('template.xml')
 json = requests.get('https://hashhub-research.com/api/articles?page=1&per=24').json()
 articles = []
 for article in json.get("articles"):
+    article_data = requests.get('https://hashhub-research.com/api/articles/' + article.get("slug")).json().get('article')
     articles.append({
         "title": article.get("title"),
         "slug": article.get("slug"),
-        "table_of_contents": article.get("table_of_contents"),
-        "pubDate": datetime.strptime(article.get("created_at"), '%Y-%m-%dT%H:%M:%S.%f%z').strftime('%a, %d %b %Y %H:%M:%S %z'),
+        "table_of_contents": article_data.get("table_of_contents"),
+        "pubDate": datetime.strptime(article.get("posted_at"), '%Y-%m-%d').strftime('%a, %d %b %Y %H:%M:%S %z'),
         "thumbnail": article.get("thumbnail"),
     })
 
 xml = tmpl.render({"articles": articles})
 with open('public/feed.xml',mode='w',encoding="utf-8") as f:
     f.write(str(xml))
+    


### PR DESCRIPTION
HashHub Research の API が以下の通り仕様変更されていたので修正しました。

- created_at が posted_at に変わり形式が変更されていた
- table_of_contents が記事一覧のリクエストに入らなくなっていた
  - slug から各記事の API を叩いて取得するように変更